### PR TITLE
circle tests should just attempt a docker build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,11 @@
 machine:
-  node:
-    version: 8
+    services:
+        - docker
+
+dependencies:
+    override:
+        - echo "Ignore CircleCI detected dependencies"
+
+test:
+    override:
+        - docker build -t steemit/overseer .


### PR DESCRIPTION
When doing circleci testing, just attempt a standard `docker build .` to mirror production build for test environment.