### PR TITLE
Add commit sha1 and docker tag to healtcheck route

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM node:8-alpine
 
+ARG SOURCE_COMMIT
+ENV SOURCE_COMMIT ${SOURCE_COMMIT}
+ARG DOCKER_TAG
+ENV DOCKER_TAG ${DOCKER_TAG}
+
 RUN apk add --no-cache make bash git
 RUN npm install -g yarn
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -48,7 +48,10 @@ app.use(rpcLogger(logger))
 router.post('/', rpc.middleware)
 
 router.get('/.well-known/healthcheck.json', async (ctx, next) => {
-    ctx.body = {ok: true}
+    ctx.body = {ok: true, 
+    source_commit: process.env.SOURCE_COMMIT,
+    docker_tag: process.env.DOCKER_TAG
+    }
 })
 
 app.use(router.routes())


### PR DESCRIPTION
I want jussi to be able to report the deployed version of all upstream services it is proxying. This PR should produce output like this from overseer's healthcheck route: 
```
{
  "status": "OK",
  "source_commit": "07d34c3c8de996e40ab96d45b8caee79c5797766",
  "docker_tag": "latest"
}
```